### PR TITLE
fix(ci): Upload coverage even when tests fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           TTA_METRICS_ENABLED: true
           TTA_TEST_METRICS_COLLECTION: true
       - name: Upload coverage to Codecov
+        if: always()  # Upload coverage even if tests fail
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -124,6 +125,7 @@ jobs:
           TTA_TEST_METRICS_COLLECTION: true
           TTA_MONITORING_INTEGRATION_TESTS: true
       - name: Upload coverage to Codecov
+        if: always()  # Upload coverage even if tests fail
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,7 +203,7 @@
         "filename": ".github/workflows/tests.yml",
         "hashed_secret": "8bb6118f8fd6935ad0876a3be34a717d32708ffd",
         "is_verified": false,
-        "line_number": 96
+        "line_number": 97
       }
     ],
     ".kiro/specs/ai-agent-orchestration/tasks.md": [
@@ -3555,5 +3555,5 @@
       }
     ]
   },
-  "generated_at": "2025-10-29T20:32:36Z"
+  "generated_at": "2025-10-29T21:42:35Z"
 }


### PR DESCRIPTION
## Problem

Codecov is not receiving coverage data despite PR #107 successfully merging the Codecov integration fixes.

**Root Cause**: The Codecov upload steps in `tests.yml` are being **skipped** because the test steps fail before reaching them. GitHub Actions skips subsequent steps when a previous step fails.

**Evidence**:
- Tests workflow run #18922684018 (after PR #107 merge):
  - Unit tests **FAILED** → Codecov upload step **SKIPPED**
  - Integration tests **FAILED** → Codecov upload step **SKIPPED**
- Test failures are due to 4 pre-existing import errors (unrelated to Codecov changes)

## Solution

Add `if: always()` condition to both Codecov upload steps in `tests.yml`:

```yaml
- name: Upload coverage to Codecov
  if: always()  # Upload coverage even if tests fail
  uses: codecov/codecov-action@v4
  ...
```

This ensures coverage files are uploaded even when tests fail, allowing Codecov to start receiving data immediately.

## Impact

✅ **Immediate Benefits**:
- Codecov will start receiving coverage data from the next workflow run
- Coverage dashboard will populate with current coverage metrics
- Import errors can be fixed separately without blocking coverage tracking

✅ **No Risks**:
- The Codecov integration from PR #107 is correct and complete
- This only changes **when** uploads happen, not **what** is uploaded
- `fail_ci_if_error: false` already prevents Codecov failures from blocking CI

## Testing

Once merged, verify:
1. Tests workflow runs and uploads coverage (even with failing tests)
2. Codecov dashboard at https://codecov.io/gh/theinterneti/TTA shows coverage data
3. Coverage flags appear: `unit`, `integration`

## Related

- PR #107 - Codecov integration fixes (merged)
- Import errors to fix separately:
  - `tests/primitives/test_error_recovery.py`
  - `tests/test_narrative_arc_orchestrator_component.py`
  - `tests/tta_prod/test_dynamic_tools_invocation_service_integration.py`
  - `tests/tta_prod/test_dynamic_tools_policy_and_metrics_integration.py`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author